### PR TITLE
Patch gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 /Debug/
 .settings/
+.settings/*
+.settings/language.settings.xml
+sysProps.xml
 .cproject
 .directory
 .project
 build.*
-.settings/language.settings.xml
 *.xml
 /Simulate/


### PR DESCRIPTION
After doing a `git reset` on files such as `settings.language.xml` and `sysProps.xml`, these changes to the `.gitignore` file should prevent changes to them from being committed, even when performing a `git commit -a`.
